### PR TITLE
CLB-517 Revert the mysql connector upgrade.

### DIFF
--- a/adapter/itest-hibernate-adapter/pom.xml
+++ b/adapter/itest-hibernate-adapter/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.45</version>
+            <version>5.1.6</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -276,7 +276,7 @@
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
-                <version>5.1.45</version>
+                <version>5.1.6</version>
             </dependency>
 
             <dependency>
@@ -359,7 +359,7 @@
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
-                <version>5.1.45</version>
+                <version>5.1.6</version>
             </dependency>
             <dependency>
                 <groupId>com.rackspacecloud</groupId>
@@ -505,7 +505,7 @@
             <dependency>
                 <groupId>mysql</groupId>
                 <artifactId>mysql-connector-java</artifactId>
-                <version>5.1.45</version>
+                <version>5.1.6</version>
                 <scope>runtime</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Reverted mysql connector to 5.1.6 to be in consistent with MySql 5.1.73

Change-Id: I2b321caf07c82aadf12c2c038b3a19c520d1f35d